### PR TITLE
取消atri推送SSL证书

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ async function noticeQmsg(options: CommonOptions) {
  */
 async function noticeAtri(options: CommonOptions) {
   checkParameters(options, ['token', 'content']);
-  const url = 'https://pushoo.tianli0.top/';
+  const url = 'http://pushoo.tianli0.top/';
   let message = getTxt(options.content);
   if (options.title) {
     message = `${options.title}\n${message}`;


### PR DESCRIPTION
因ssl证书有bug会提示message:unable to verify the first certificate,name:Error,stack:Error: unable to verify the first certificaten at TLSSocket.onConnectSecure (_tls_wrap.js:1051:34)，暂时取消取消atri推送https设置，待服务端修复后恢复ssl