### PR TITLE
fix: escape special characters in telegram content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -363,7 +363,7 @@ async function noticeTelegram(options: CommonOptions) {
     },
     ['tgToken', 'chatId'],
   );
-  let text = options.content;
+  let text = options.content.replace(/([*_])/g, '\\$1'); // * 和 _ 似乎需要转义，否则会抛出 400 Bad Request 以及消息显示不正常
   if (options.title) {
     text = `${options.title}\n\n${text}`;
   }


### PR DESCRIPTION
参见：
- https://github.com/twikoojs/twikoo/pull/759
- https://github.com/twikoojs/twikoo/issues/396

`*`和`_`不转义，似乎无法正常发送消息。